### PR TITLE
Use $- to determine if interactive

### DIFF
--- a/bashrc_dispatch
+++ b/bashrc_dispatch
@@ -41,7 +41,7 @@ if ! type -p shell_is_login ; then
   shell_is_osx         () { [[ "$OSTYPE" == *'darwin'* ]] ; }
   shell_is_cygwin      () { [[ "$OSTYPE" == *'cygwin'* ]] ; }
   shell_is_login       () { shopt -q login_shell ; }
-  shell_is_interactive () { test -n "$PS1" ; }
+  shell_is_interactive () { [[ "$-" == *'i'* ]] ; }
   shell_is_script      () { ! shell_is_interactive ; }
 fi
 


### PR DESCRIPTION
Instead of checking for environment variable $PS1 (which could be blindly set by a user or script somewhere), ask Bash if it is interactive by interrogating $- automatic variable. If it contains 'i' then the shell was started interactively.